### PR TITLE
SLING-9806 - Export the johnzon.core packages provided by org.apache.johnzon:johnzon-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
                         <id>bnd-process</id>
                         <configuration>
                             <bnd><![CDATA[
-Export-Package: javax.json.*;-split-package:=first
-Private-Package: org.apache.johnzon.core
+Export-Package: javax.json.*;-split-package:=first,org.apache.johnzon.core.*
 Import-Package:
 # Taken over from the embedded geronimo-json_1.1_spec
 Provide-Capability: osgi.contract;osgi.contract=JavaJSONP;uses:="javax.json,javax.json.spi,javax.json.stream";version:List<Version>="1.1,1.0"


### PR DESCRIPTION
With this patch, the `Export-Package` header looks like:
```
Export-Package: javax.json;version="1.1";uses:="javax.json.stream",jav
 ax.json.spi;version="1.1";uses:="javax.json,javax.json.stream",javax.
 json.stream;version="1.1";uses:="javax.json",org.apache.johnzon.core;
 version="1.2.8";uses:="javax.json,javax.json.spi,javax.json.stream",o
 rg.apache.johnzon.core.util;version="1.2.8"
```